### PR TITLE
Add CSV bank statement import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# OFX/OFC Reader
-Read the OFX (Open Financial Exchange) and OFC (Open Financial Connectivity) file formats.
+# OFX/OFC/CSV Reader
+Read OFX (Open Financial Exchange), OFC (Open Financial Connectivity), and CSV bank statement files.
 
 
 About
 -------
 
-   * Importing the OFX/OFC file allows you to save time in financial management. Instead of typing or throwing each drive manually, you download the current account statement or savings in this file format.
+   * Importing OFX, OFC, or CSV files allows you to save time in financial management. Instead of typing each transaction manually, you import the statement downloaded from the bank.
 
    * OFX/OFC file format is widely used in Internet Banking of the leading financial institutions in the world.
 
@@ -22,6 +22,17 @@ $ boss install github.com/leogregianin/ofx-reader
  
 Example
 -------
+
+`TOFXReader.Import` detects CSV files by their `.csv` extension, so consumers use the same reader API for every supported format:
+
+```pascal
+Reader.OFXFile := 'statement.csv';
+if Reader.Import then
+  for I := 0 to Reader.Count - 1 do
+    ProcessTransaction(Reader.Get(I));
+```
+
+CSV parsing is implemented in the separate `src/uExtratoCsvReader.pas` unit and exposed through `TOFXReader`. It supports quoted fields, comma/semicolon/tab delimiters, UTF-8, UTF-16 and Windows-1252 text, Brazilian and international numeric formats, and common bank-statement column names. CSV support currently targets Delphi builds; OFX/OFC support remains available to Lazarus/FPC consumers.
 
 Simple result:
 

--- a/boss.json
+++ b/boss.json
@@ -1,7 +1,7 @@
 {
 	"name": "ofx-reader",
-	"description": "OFX (Open Financial Exchange) file formats library",
-	"version": "1.0.0",
+	"description": "OFX, OFC and CSV bank statement formats library",
+	"version": "1.1.0",
 	"homepage": "https://github.com/leogregianin/ofx-reader",
 	"mainsrc": "./",
 	"projects": [],

--- a/src/ofxreader.pas
+++ b/src/ofxreader.pas
@@ -335,7 +335,10 @@ begin
     begin
       Transacao := CSVReader[I];
       Item := Add;
-      Item.MovType := Transacao.Tipo;
+if Transacao.Tipo = 'DEBIT' then
+        Item.MovType := 'D'
+      else
+        Item.MovType := 'C';
       Item.MovDate := Transacao.Data;
       Item.Value := CurrToStr(Transacao.Valor, TFormatSettings.Invariant);
       Item.ID := Transacao.Documento;

--- a/src/ofxreader.pas
+++ b/src/ofxreader.pas
@@ -1,4 +1,4 @@
-//
+﻿//
 // OFX - Open Financial Exchange
 // OFC - Open Financial Connectivity
 
@@ -24,6 +24,7 @@ type
     Document: string;
     Description: string;
     Name: string;
+    SourceKey: string;
   end;
 
   TOFXReader = class(TComponent)
@@ -45,7 +46,9 @@ type
     FOFXFile: string;
     FOFXContent: string;
     FListItems: TList;
+    function ImportCSV: Boolean;
     procedure Clear;
+    procedure Reset;
     procedure Delete(iIndex: integer);
     function Add: TOFXItem;
     function InfLine(sLine: string): string;
@@ -61,6 +64,11 @@ type
 procedure Register;
 
 implementation
+
+{$IFNDEF FPC}
+uses
+  uExtratoCsvReader;
+{$ENDIF}
 
 constructor TOFXReader.Create(AOwner: TComponent);
 begin
@@ -86,6 +94,18 @@ begin
   while FListItems.Count > 0 do
     Delete(0);
   FListItems.Clear;
+end;
+
+procedure TOFXReader.Reset;
+begin
+  Clear;
+  BankID := '';
+  BranchID := '';
+  AccountID := '';
+  AccountType := '';
+  DateStart := '';
+  DateEnd := '';
+  FinalBalance := '';
 end;
 
 function TOFXReader.ConvertDate(DataStr: string): TDateTime;
@@ -138,13 +158,14 @@ var
   oItem: TOFXItem;
   sLine: string;
 begin
-  Clear;
-  DateStart := '';
-  DateEnd := '';
+  Reset;
   bOFX := false;
 
   if (FOFXContent = '') and (not FileExists(FOFXFile)) then
     raise Exception.Create('File not found!');
+
+  if (FOFXContent = '') and SameText(ExtractFileExt(FOFXFile), '.csv') then
+    Exit(ImportCSV);
 
   oFile := TStringList.Create;
   try
@@ -291,6 +312,45 @@ begin
     oFile.Free;
   end;
 end;
+
+function TOFXReader.ImportCSV: Boolean;
+{$IFDEF FPC}
+begin
+  raise Exception.Create('CSV import is not available in Lazarus/FPC builds.');
+end;
+{$ELSE}
+var
+  CSVReader: TExtratoCsvReader;
+  I: Integer;
+  Item: TOFXItem;
+  Transacao: TExtratoCsvTransacao;
+begin
+  CSVReader := TExtratoCsvReader.Create;
+  try
+    CSVReader.CarregarArquivo(FOFXFile);
+    DateStart := DateToStr(CSVReader.DataInicial);
+    DateEnd := DateToStr(CSVReader.DataFinal);
+
+    for I := 0 to CSVReader.Count - 1 do
+    begin
+      Transacao := CSVReader[I];
+      Item := Add;
+      Item.MovType := Transacao.Tipo;
+      Item.MovDate := Transacao.Data;
+      Item.Value := CurrToStr(Transacao.Valor, TFormatSettings.Invariant);
+      Item.ID := Transacao.Documento;
+      Item.RefNum := Transacao.Documento;
+      Item.Document := Transacao.Documento;
+      Item.Description := Transacao.Descricao;
+      Item.SourceKey := 'CSV|' + Transacao.ChaveOrigem;
+    end;
+
+    Result := Count > 0;
+  finally
+    CSVReader.Free;
+  end;
+end;
+{$ENDIF}
 
 function TOFXReader.InfLine(sLine: string): string;
 var

--- a/src/uExtratoCsvReader.pas
+++ b/src/uExtratoCsvReader.pas
@@ -1,0 +1,611 @@
+﻿unit uExtratoCsvReader;
+
+interface
+
+uses
+  System.Classes, System.Generics.Collections, System.SysUtils;
+
+type
+  TExtratoCsvTransacao = record
+    Data: TDate;
+    Descricao: string;
+    Documento: string;
+    Valor: Currency;
+    Tipo: string;
+    ChaveOrigem: string;
+    Linha: Integer;
+  end;
+
+  TExtratoCsvReader = class
+  private
+    FTransacoes: TList<TExtratoCsvTransacao>;
+    FOcorrencias: TDictionary<string, Integer>;
+    FDataInicial: TDate;
+    FDataFinal: TDate;
+    FCabecalhoProcessado: Boolean;
+    FIndiceData: Integer;
+    FIndiceDescricao: Integer;
+    FIndiceDetalhes: Integer;
+    FIndiceDocumento: Integer;
+    FIndiceValor: Integer;
+    FIndiceTipo: Integer;
+    function GetCount: Integer;
+    function GetTransacao(Index: Integer): TExtratoCsvTransacao;
+    class function DetectarDelimitador(const Texto: string): Char; static;
+    class function EhUtf8Valido(const Bytes: TBytes; Inicio: Integer): Boolean; static;
+    class function LerArquivoTexto(const Arquivo: string): string; static;
+    class function Normalizar(const Valor: string): string; static;
+    class function TryLerData(const Valor: string; out Data: TDate): Boolean; static;
+    class function TryLerValor(const Texto: string; out Valor: Currency): Boolean; static;
+    class function ValorCampo(Campos: TStrings; Indice: Integer): string; static;
+    class function EncontrarColuna(Cabecalhos: TStrings;
+      const Nomes: array of string): Integer; static;
+    class function EhLinhaEmBranco(Campos: TStrings): Boolean; static;
+    class function EhLinhaSaldo(const Descricao: string): Boolean; static;
+    procedure AnalisarTexto(const Texto: string; Delimitador: Char);
+    procedure ProcessarLinha(Campos: TStrings; NumeroLinha: Integer);
+    procedure ProcessarCabecalho(Campos: TStrings; NumeroLinha: Integer);
+    procedure ProcessarTransacao(Campos: TStrings; NumeroLinha: Integer);
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure CarregarArquivo(const Arquivo: string);
+    property Count: Integer read GetCount;
+    property DataInicial: TDate read FDataInicial;
+    property DataFinal: TDate read FDataFinal;
+    property Transacoes[Index: Integer]: TExtratoCsvTransacao read GetTransacao; default;
+  end;
+
+implementation
+
+uses
+  System.IOUtils, System.Math;
+
+constructor TExtratoCsvReader.Create;
+begin
+  inherited Create;
+  FTransacoes := TList<TExtratoCsvTransacao>.Create;
+  FOcorrencias := TDictionary<string, Integer>.Create;
+end;
+
+destructor TExtratoCsvReader.Destroy;
+begin
+  FOcorrencias.Free;
+  FTransacoes.Free;
+  inherited;
+end;
+
+procedure TExtratoCsvReader.CarregarArquivo(const Arquivo: string);
+var
+  Texto: string;
+begin
+  FTransacoes.Clear;
+  FOcorrencias.Clear;
+  FDataInicial := 0;
+  FDataFinal := 0;
+  FCabecalhoProcessado := False;
+  FIndiceData := -1;
+  FIndiceDescricao := -1;
+  FIndiceDetalhes := -1;
+  FIndiceDocumento := -1;
+  FIndiceValor := -1;
+  FIndiceTipo := -1;
+
+  Texto := LerArquivoTexto(Arquivo);
+  if Texto.Trim.IsEmpty then
+    raise Exception.Create('O arquivo CSV está vazio.');
+
+  AnalisarTexto(Texto, DetectarDelimitador(Texto));
+  if not FCabecalhoProcessado then
+    raise Exception.Create('Não foi possível localizar o cabeçalho do arquivo CSV.');
+  if FTransacoes.Count = 0 then
+    raise Exception.Create('Arquivo CSV importado sem movimentação bancária.');
+end;
+
+function TExtratoCsvReader.GetCount: Integer;
+begin
+  Result := FTransacoes.Count;
+end;
+
+function TExtratoCsvReader.GetTransacao(Index: Integer): TExtratoCsvTransacao;
+begin
+  Result := FTransacoes[Index];
+end;
+
+class function TExtratoCsvReader.EhUtf8Valido(const Bytes: TBytes;
+  Inicio: Integer): Boolean;
+var
+  I, Tamanho: Integer;
+  B: Byte;
+
+  function Continuacao(Indice: Integer): Boolean;
+  begin
+    Result := (Indice < Tamanho) and ((Bytes[Indice] and $C0) = $80);
+  end;
+
+begin
+  I := Inicio;
+  Tamanho := Length(Bytes);
+  while I < Tamanho do
+  begin
+    B := Bytes[I];
+    if B <= $7F then
+      Inc(I)
+    else if (B >= $C2) and (B <= $DF) and Continuacao(I + 1) then
+      Inc(I, 2)
+    else if (B = $E0) and (I + 2 < Tamanho) and
+      (Bytes[I + 1] >= $A0) and (Bytes[I + 1] <= $BF) and Continuacao(I + 2) then
+      Inc(I, 3)
+    else if (((B >= $E1) and (B <= $EC)) or ((B >= $EE) and (B <= $EF))) and
+      Continuacao(I + 1) and Continuacao(I + 2) then
+      Inc(I, 3)
+    else if (B = $ED) and (I + 2 < Tamanho) and
+      (Bytes[I + 1] >= $80) and (Bytes[I + 1] <= $9F) and Continuacao(I + 2) then
+      Inc(I, 3)
+    else if (B = $F0) and (I + 3 < Tamanho) and
+      (Bytes[I + 1] >= $90) and (Bytes[I + 1] <= $BF) and
+      Continuacao(I + 2) and Continuacao(I + 3) then
+      Inc(I, 4)
+    else if (B >= $F1) and (B <= $F3) and Continuacao(I + 1) and
+      Continuacao(I + 2) and Continuacao(I + 3) then
+      Inc(I, 4)
+    else if (B = $F4) and (I + 3 < Tamanho) and
+      (Bytes[I + 1] >= $80) and (Bytes[I + 1] <= $8F) and
+      Continuacao(I + 2) and Continuacao(I + 3) then
+      Inc(I, 4)
+    else
+      Exit(False);
+  end;
+  Result := True;
+end;
+
+class function TExtratoCsvReader.LerArquivoTexto(const Arquivo: string): string;
+var
+  Bytes: TBytes;
+  Encoding: TEncoding;
+begin
+  Bytes := TFile.ReadAllBytes(Arquivo);
+  if (Length(Bytes) >= 3) and (Bytes[0] = $EF) and (Bytes[1] = $BB) and
+    (Bytes[2] = $BF) then
+    Exit(TEncoding.UTF8.GetString(Bytes, 3, Length(Bytes) - 3));
+
+  if (Length(Bytes) >= 2) and (Bytes[0] = $FF) and (Bytes[1] = $FE) then
+    Exit(TEncoding.Unicode.GetString(Bytes, 2, Length(Bytes) - 2));
+
+  if (Length(Bytes) >= 2) and (Bytes[0] = $FE) and (Bytes[1] = $FF) then
+    Exit(TEncoding.BigEndianUnicode.GetString(Bytes, 2, Length(Bytes) - 2));
+
+  if EhUtf8Valido(Bytes, 0) then
+    Exit(TEncoding.UTF8.GetString(Bytes));
+
+  Encoding := TEncoding.GetEncoding(1252);
+  try
+    Result := Encoding.GetString(Bytes);
+  finally
+    Encoding.Free;
+  end;
+end;
+
+class function TExtratoCsvReader.DetectarDelimitador(const Texto: string): Char;
+var
+  I, Virgulas, PontoVirgulas, Tabulacoes: Integer;
+  EntreAspas: Boolean;
+begin
+  if Texto.StartsWith('sep=', True) and (Texto.Length >= 5) then
+    Exit(Texto[5]);
+
+  Virgulas := 0;
+  PontoVirgulas := 0;
+  Tabulacoes := 0;
+  EntreAspas := False;
+  I := 1;
+  while I <= Texto.Length do
+  begin
+    if Texto[I] = '"' then
+    begin
+      if EntreAspas and (I < Texto.Length) and (Texto[I + 1] = '"') then
+        Inc(I)
+      else
+        EntreAspas := not EntreAspas;
+    end
+    else if not EntreAspas then
+    begin
+      case Texto[I] of
+        ',': Inc(Virgulas);
+        ';': Inc(PontoVirgulas);
+        #9: Inc(Tabulacoes);
+        #10, #13: Break;
+      end;
+    end;
+    Inc(I);
+  end;
+
+  if (Virgulas = 0) and (PontoVirgulas = 0) and (Tabulacoes = 0) then
+    raise Exception.Create('Não foi possível identificar o separador do arquivo CSV.');
+  if (PontoVirgulas >= Virgulas) and (PontoVirgulas >= Tabulacoes) then
+    Result := ';'
+  else if Tabulacoes >= Virgulas then
+    Result := #9
+  else
+    Result := ',';
+end;
+
+procedure TExtratoCsvReader.AnalisarTexto(const Texto: string;
+  Delimitador: Char);
+var
+  Campo: TStringBuilder;
+  Campos: TStringList;
+  I, LinhaAtual, LinhaRegistro: Integer;
+  EntreAspas: Boolean;
+  C: Char;
+
+  procedure FinalizarCampo;
+  begin
+    Campos.Add(Campo.ToString);
+    Campo.Clear;
+  end;
+
+  procedure FinalizarLinha;
+  begin
+    FinalizarCampo;
+    ProcessarLinha(Campos, LinhaRegistro);
+    Campos.Clear;
+    LinhaRegistro := LinhaAtual + 1;
+  end;
+
+begin
+  Campo := TStringBuilder.Create;
+  Campos := TStringList.Create;
+  try
+    EntreAspas := False;
+    LinhaAtual := 1;
+    LinhaRegistro := 1;
+    I := 1;
+    while I <= Texto.Length do
+    begin
+      C := Texto[I];
+      if EntreAspas then
+      begin
+        if C = '"' then
+        begin
+          if (I < Texto.Length) and (Texto[I + 1] = '"') then
+          begin
+            Campo.Append('"');
+            Inc(I);
+          end
+          else
+            EntreAspas := False;
+        end
+        else
+        begin
+          Campo.Append(C);
+          if C = #10 then
+            Inc(LinhaAtual);
+        end;
+      end
+      else if (C = '"') and (Campo.Length = 0) then
+        EntreAspas := True
+      else if C = Delimitador then
+        FinalizarCampo
+      else if (C = #10) or (C = #13) then
+      begin
+        FinalizarLinha;
+        if (C = #13) and (I < Texto.Length) and (Texto[I + 1] = #10) then
+          Inc(I);
+        Inc(LinhaAtual);
+      end
+      else
+        Campo.Append(C);
+      Inc(I);
+    end;
+
+    if EntreAspas then
+      raise Exception.CreateFmt('Aspas não finalizadas no arquivo CSV, a partir da linha %d.',
+        [LinhaRegistro]);
+    if (Campo.Length > 0) or (Campos.Count > 0) then
+      FinalizarLinha;
+  finally
+    Campos.Free;
+    Campo.Free;
+  end;
+end;
+
+procedure TExtratoCsvReader.ProcessarLinha(Campos: TStrings;
+  NumeroLinha: Integer);
+begin
+  if EhLinhaEmBranco(Campos) then
+    Exit;
+  if (not FCabecalhoProcessado) and (Campos.Count = 1) and
+    Campos[0].Trim.StartsWith('sep=', True) then
+    Exit;
+  if not FCabecalhoProcessado then
+    ProcessarCabecalho(Campos, NumeroLinha)
+  else
+    ProcessarTransacao(Campos, NumeroLinha);
+end;
+
+procedure TExtratoCsvReader.ProcessarCabecalho(Campos: TStrings;
+  NumeroLinha: Integer);
+var
+  Ausentes: string;
+begin
+  FIndiceData := EncontrarColuna(Campos,
+    ['DATA', 'DATA MOVIMENTO', 'DATA LANCAMENTO', 'DATE']);
+  FIndiceDescricao := EncontrarColuna(Campos,
+    ['LANCAMENTO', 'HISTORICO', 'DESCRICAO', 'DESCRICAO DETALHADA', 'MEMO']);
+  FIndiceDetalhes := EncontrarColuna(Campos,
+    ['DETALHES', 'COMPLEMENTO', 'DESCRICAO DETALHADA']);
+  FIndiceDocumento := EncontrarColuna(Campos,
+    ['N DOCUMENTO', 'NUMERO DOCUMENTO', 'DOCUMENTO', 'DOC',
+     'ID TRANSACAO', 'IDENTIFICADOR']);
+  FIndiceValor := EncontrarColuna(Campos,
+    ['VALOR', 'VALOR LANCAMENTO', 'AMOUNT']);
+  FIndiceTipo := EncontrarColuna(Campos,
+    ['TIPO LANCAMENTO', 'TIPO', 'NATUREZA', 'DEBITO CREDITO',
+     'ENTRADA SAIDA']);
+
+  Ausentes := '';
+  if FIndiceData < 0 then
+    Ausentes := 'Data';
+  if FIndiceDescricao < 0 then
+  begin
+    if Ausentes <> '' then
+      Ausentes := Ausentes + ', ';
+    Ausentes := Ausentes + 'Lançamento/Descrição';
+  end;
+  if FIndiceValor < 0 then
+  begin
+    if Ausentes <> '' then
+      Ausentes := Ausentes + ', ';
+    Ausentes := Ausentes + 'Valor';
+  end;
+  if Ausentes <> '' then
+    raise Exception.CreateFmt('Cabeçalho CSV incompatível na linha %d. Colunas não localizadas: %s.',
+      [NumeroLinha, Ausentes]);
+  FCabecalhoProcessado := True;
+end;
+
+procedure TExtratoCsvReader.ProcessarTransacao(Campos: TStrings;
+  NumeroLinha: Integer);
+var
+  Transacao: TExtratoCsvTransacao;
+  DataTexto, Descricao, Detalhes, TipoOriginal, TipoNormalizado: string;
+  BaseChave: string;
+  Ocorrencia: Integer;
+  Valor: Currency;
+begin
+  Descricao := ValorCampo(Campos, FIndiceDescricao).Trim;
+  Detalhes := ValorCampo(Campos, FIndiceDetalhes).Trim;
+  if EhLinhaSaldo(Descricao) or EhLinhaSaldo(Detalhes) then
+    Exit;
+
+  DataTexto := ValorCampo(Campos, FIndiceData).Trim;
+  if not TryLerData(DataTexto, Transacao.Data) then
+    raise Exception.CreateFmt('Data inválida na linha %d do arquivo CSV.', [NumeroLinha]);
+
+  if not TryLerValor(ValorCampo(Campos, FIndiceValor), Valor) then
+    raise Exception.CreateFmt('Valor inválido na linha %d do arquivo CSV.', [NumeroLinha]);
+
+  TipoOriginal := ValorCampo(Campos, FIndiceTipo).Trim;
+  TipoNormalizado := Normalizar(TipoOriginal);
+  if (TipoNormalizado = 'SAIDA') or (TipoNormalizado = 'DEBITO') or
+    (TipoNormalizado = 'DEBIT') or (TipoNormalizado = 'D') then
+  begin
+    Valor := -Abs(Valor);
+    Transacao.Tipo := 'DEBIT';
+  end
+  else if (TipoNormalizado = 'ENTRADA') or (TipoNormalizado = 'CREDITO') or
+    (TipoNormalizado = 'CREDIT') or (TipoNormalizado = 'C') then
+  begin
+    Valor := Abs(Valor);
+    Transacao.Tipo := 'CREDIT';
+  end
+  else if Valor < 0 then
+    Transacao.Tipo := 'DEBIT'
+  else
+    Transacao.Tipo := 'CREDIT';
+
+  if (Descricao = '') and (Detalhes = '') then
+    raise Exception.CreateFmt('Descrição não informada na linha %d do arquivo CSV.',
+      [NumeroLinha]);
+  if (Detalhes <> '') and not SameText(Descricao, Detalhes) then
+  begin
+    if Descricao <> '' then
+      Descricao := Descricao + ' | ' + Detalhes
+    else
+      Descricao := Detalhes;
+  end;
+
+  Transacao.Descricao := Descricao;
+  Transacao.Documento := ValorCampo(Campos, FIndiceDocumento).Trim;
+  Transacao.Valor := Valor;
+  Transacao.Linha := NumeroLinha;
+
+  BaseChave := FormatDateTime('yyyymmdd', Transacao.Data) + '|' +
+    Transacao.Documento + '|' +
+    CurrToStr(Transacao.Valor, TFormatSettings.Invariant) + '|' +
+    Transacao.Descricao;
+  if not FOcorrencias.TryGetValue(BaseChave, Ocorrencia) then
+    Ocorrencia := 0;
+  Inc(Ocorrencia);
+  FOcorrencias.AddOrSetValue(BaseChave, Ocorrencia);
+  Transacao.ChaveOrigem := BaseChave + '|' + Ocorrencia.ToString;
+
+  FTransacoes.Add(Transacao);
+  if (FDataInicial = 0) or (Transacao.Data < FDataInicial) then
+    FDataInicial := Transacao.Data;
+  if (FDataFinal = 0) or (Transacao.Data > FDataFinal) then
+    FDataFinal := Transacao.Data;
+end;
+
+class function TExtratoCsvReader.ValorCampo(Campos: TStrings;
+  Indice: Integer): string;
+begin
+  if (Indice >= 0) and (Indice < Campos.Count) then
+    Result := Campos[Indice]
+  else
+    Result := '';
+end;
+
+class function TExtratoCsvReader.EncontrarColuna(Cabecalhos: TStrings;
+  const Nomes: array of string): Integer;
+var
+  I, J: Integer;
+  Cabecalho: string;
+begin
+  for I := 0 to Cabecalhos.Count - 1 do
+  begin
+    Cabecalho := Normalizar(Cabecalhos[I]);
+    for J := Low(Nomes) to High(Nomes) do
+      if Cabecalho = Normalizar(Nomes[J]) then
+        Exit(I);
+  end;
+  Result := -1;
+end;
+
+class function TExtratoCsvReader.Normalizar(const Valor: string): string;
+var
+  Texto: string;
+  I: Integer;
+  C: Char;
+begin
+  Texto := Valor.Trim;
+  Result := '';
+  for I := 1 to Texto.Length do
+  begin
+    case Texto[I] of
+      'á', 'à', 'ã', 'â', 'ä', 'Á', 'À', 'Ã', 'Â', 'Ä': C := 'A';
+      'é', 'è', 'ê', 'ë', 'É', 'È', 'Ê', 'Ë': C := 'E';
+      'í', 'ì', 'î', 'ï', 'Í', 'Ì', 'Î', 'Ï': C := 'I';
+      'ó', 'ò', 'õ', 'ô', 'ö', 'Ó', 'Ò', 'Õ', 'Ô', 'Ö': C := 'O';
+      'ú', 'ù', 'û', 'ü', 'Ú', 'Ù', 'Û', 'Ü': C := 'U';
+      'ç', 'Ç': C := 'C';
+      'ñ', 'Ñ': C := 'N';
+    else
+      C := UpCase(Texto[I]);
+    end;
+    if CharInSet(C, ['A'..'Z', '0'..'9']) then
+      Result := Result + C;
+  end;
+end;
+
+class function TExtratoCsvReader.TryLerData(const Valor: string;
+  out Data: TDate): Boolean;
+var
+  Texto: string;
+  Dia, Mes, Ano: Word;
+  DiaInt, MesInt, AnoInt: Integer;
+  DataHora: TDateTime;
+begin
+  Result := False;
+  Texto := Valor.Trim;
+  if Texto.Length >= 10 then
+    Texto := Texto.Substring(0, 10);
+
+  if (Texto.Length = 10) and (Texto[3] = '/') and (Texto[6] = '/') then
+  begin
+    if not TryStrToInt(Copy(Texto, 1, 2), DiaInt) or
+      not TryStrToInt(Copy(Texto, 4, 2), MesInt) or
+      not TryStrToInt(Copy(Texto, 7, 4), AnoInt) then
+      Exit;
+  end
+  else if (Texto.Length = 10) and (Texto[5] = '-') and (Texto[8] = '-') then
+  begin
+    if not TryStrToInt(Copy(Texto, 1, 4), AnoInt) or
+      not TryStrToInt(Copy(Texto, 6, 2), MesInt) or
+      not TryStrToInt(Copy(Texto, 9, 2), DiaInt) then
+      Exit;
+  end
+  else
+    Exit;
+  if (DiaInt < Low(Word)) or (DiaInt > High(Word)) or
+    (MesInt < Low(Word)) or (MesInt > High(Word)) or
+    (AnoInt < Low(Word)) or (AnoInt > High(Word)) then
+    Exit;
+  Dia := DiaInt;
+  Mes := MesInt;
+  Ano := AnoInt;
+  Result := TryEncodeDate(Ano, Mes, Dia, DataHora);
+  if Result then
+    Data := DataHora;
+end;
+
+class function TExtratoCsvReader.TryLerValor(const Texto: string;
+  out Valor: Currency): Boolean;
+var
+  Limpo: string;
+  Numero: TStringBuilder;
+  I, UltimaVirgula, UltimoPonto, PosicaoDecimal: Integer;
+  Negativo: Boolean;
+  C: Char;
+begin
+  Limpo := Texto.Trim;
+  Limpo := StringReplace(Limpo, #$00A0, '', [rfReplaceAll]);
+  Limpo := StringReplace(Limpo, ' ', '', [rfReplaceAll]);
+  Limpo := StringReplace(UpperCase(Limpo), 'BRL', '', [rfReplaceAll]);
+  Limpo := StringReplace(Limpo, 'R$', '', [rfReplaceAll]);
+  Limpo := StringReplace(Limpo, '$', '', [rfReplaceAll]);
+  Negativo := (Limpo.Contains('-')) or
+    (Limpo.StartsWith('(') and Limpo.EndsWith(')'));
+  Limpo := StringReplace(Limpo, '-', '', [rfReplaceAll]);
+  Limpo := StringReplace(Limpo, '+', '', [rfReplaceAll]);
+  Limpo := StringReplace(Limpo, '(', '', [rfReplaceAll]);
+  Limpo := StringReplace(Limpo, ')', '', [rfReplaceAll]);
+  for I := 1 to Limpo.Length do
+    if not CharInSet(Limpo[I], ['0'..'9', ',', '.']) then
+      Exit(False);
+  UltimaVirgula := Limpo.LastIndexOf(',') + 1;
+  UltimoPonto := Limpo.LastIndexOf('.') + 1;
+  PosicaoDecimal := 0;
+
+  if (UltimaVirgula > 0) and (UltimoPonto > 0) then
+    PosicaoDecimal := Max(UltimaVirgula, UltimoPonto)
+  else if UltimaVirgula > 0 then
+  begin
+    if (Limpo.Length - UltimaVirgula >= 1) and
+      (Limpo.Length - UltimaVirgula <= 2) then
+      PosicaoDecimal := UltimaVirgula;
+  end
+  else if UltimoPonto > 0 then
+  begin
+    if (Limpo.Length - UltimoPonto >= 1) and
+      (Limpo.Length - UltimoPonto <= 2) then
+      PosicaoDecimal := UltimoPonto;
+  end;
+
+  Numero := TStringBuilder.Create;
+  try
+    for I := 1 to Limpo.Length do
+    begin
+      C := Limpo[I];
+      if CharInSet(C, ['0'..'9']) then
+        Numero.Append(C)
+      else if (I = PosicaoDecimal) and CharInSet(C, [',', '.']) then
+        Numero.Append('.');
+    end;
+    if Numero.Length = 0 then
+      Exit(False);
+    Result := TryStrToCurr(Numero.ToString, Valor, TFormatSettings.Invariant);
+  finally
+    Numero.Free;
+  end;
+  if Result and Negativo then
+    Valor := -Abs(Valor);
+end;
+
+class function TExtratoCsvReader.EhLinhaEmBranco(Campos: TStrings): Boolean;
+var
+  I: Integer;
+begin
+  for I := 0 to Campos.Count - 1 do
+    if not Campos[I].Trim.IsEmpty then
+      Exit(False);
+  Result := True;
+end;
+
+class function TExtratoCsvReader.EhLinhaSaldo(const Descricao: string): Boolean;
+begin
+  Result := Normalizar(Descricao).StartsWith('SALDO');
+end;
+
+end.

--- a/tests/CSV/CsvReaderTests.dpr
+++ b/tests/CSV/CsvReaderTests.dpr
@@ -1,0 +1,190 @@
+﻿program CsvReaderTests;
+
+{$APPTYPE CONSOLE}
+
+uses
+  System.SysUtils,
+  System.Math,
+  System.Diagnostics,
+  ofxreader in '..\..\src\ofxreader.pas',
+  uExtratoCsvReader in '..\..\src\uExtratoCsvReader.pas';
+
+procedure Verificar(Condicao: Boolean; const Mensagem: string);
+begin
+  if not Condicao then
+    raise Exception.Create(Mensagem);
+end;
+
+procedure VerificarMoeda(const Nome: string; Atual, Esperado: Currency);
+begin
+  if Abs(Atual - Esperado) > 0.0001 then
+    raise Exception.CreateFmt('%s: esperado %.2f, recebido %.2f',
+      [Nome, Esperado, Atual]);
+end;
+
+function CaminhoFixture(const Nome: string): string;
+begin
+  Result := IncludeTrailingPathDelimiter(ExtractFilePath(ParamStr(0))) +
+    'fixtures\' + Nome;
+end;
+
+function LerValor(const Texto: string): Currency;
+begin
+  if not TryStrToCurr(Texto, Result, TFormatSettings.Invariant) then
+    raise Exception.Create('Valor inválido retornado pelo TOFXReader: ' + Texto);
+end;
+
+function Somar(Reader: TOFXReader): Currency;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := 0 to Reader.Count - 1 do
+    Result := Result + LerValor(Reader.Get(I).Value);
+end;
+
+procedure ObterPeriodo(Reader: TOFXReader; out DataInicial, DataFinal: TDateTime);
+var
+  I: Integer;
+begin
+  Verificar(Reader.Count > 0, 'O leitor não retornou movimentações.');
+  DataInicial := Reader.Get(0).MovDate;
+  DataFinal := DataInicial;
+  for I := 1 to Reader.Count - 1 do
+  begin
+    if Reader.Get(I).MovDate < DataInicial then
+      DataInicial := Reader.Get(I).MovDate;
+    if Reader.Get(I).MovDate > DataFinal then
+      DataFinal := Reader.Get(I).MovDate;
+  end;
+end;
+
+procedure Importar(Reader: TOFXReader; const Arquivo: string);
+begin
+  Reader.OFXFile := Arquivo;
+  Verificar(Reader.Import, 'O TOFXReader recusou o arquivo CSV.');
+end;
+
+procedure TestarModeloBancoBrasil;
+var
+  Reader: TOFXReader;
+  DataInicial, DataFinal: TDateTime;
+begin
+  Reader := TOFXReader.Create(nil);
+  try
+    Importar(Reader, CaminhoFixture('banco-brasil.csv'));
+    ObterPeriodo(Reader, DataInicial, DataFinal);
+    Verificar(Reader.Count = 3, 'Banco do Brasil: quantidade de movimentações');
+    Verificar(DataInicial = EncodeDate(2026, 7, 1),
+      'Banco do Brasil: data inicial');
+    Verificar(DataFinal = EncodeDate(2026, 7, 3),
+      'Banco do Brasil: data final');
+    VerificarMoeda('Banco do Brasil: soma', Somar(Reader), 129.55);
+    Verificar(Reader.Get(0).Description =
+      'Pix - Recebido | CLIENTE, TESTE',
+      'Banco do Brasil: descrição e detalhes');
+    Verificar(LerValor(Reader.Get(1).Value) = -100.50,
+      'Banco do Brasil: tipo Saída deve definir sinal negativo');
+    Verificar(Reader.Get(2).MovType = 'DEBIT',
+      'Banco do Brasil: tipo de movimento normalizado');
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TestarUtf8PontoVirgula;
+var
+  Reader: TOFXReader;
+begin
+  Reader := TOFXReader.Create(nil);
+  try
+    Importar(Reader, CaminhoFixture('utf8-ponto-virgula.csv'));
+    Verificar(Reader.Count = 4, 'UTF-8: quantidade de movimentações');
+    VerificarMoeda('UTF-8: soma', Somar(Reader), 9.00);
+    Verificar(Reader.Get(1).Description = 'Compra; material',
+      'UTF-8: separador dentro de campo entre aspas');
+    Verificar(Reader.Get(2).SourceKey <> Reader.Get(3).SourceKey,
+      'UTF-8: transações idênticas precisam de chaves distintas');
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TestarCabecalhoInvalido;
+var
+  Reader: TOFXReader;
+  Rejeitado: Boolean;
+begin
+  Reader := TOFXReader.Create(nil);
+  try
+    Rejeitado := False;
+    try
+      Importar(Reader, CaminhoFixture('cabecalho-invalido.csv'));
+    except
+      on E: Exception do
+        Rejeitado := Pos('Colunas não localizadas', E.Message) > 0;
+    end;
+    Verificar(Rejeitado,
+      'CSV incompatível deve ser rejeitado com uma mensagem objetiva');
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure TestarFormatoLegado(const Nome: string);
+var
+  Reader: TOFXReader;
+begin
+  Reader := TOFXReader.Create(nil);
+  try
+    Reader.OFXFile := CaminhoFixture(Nome);
+    Verificar(Reader.Import, Nome + ': formato legado não reconhecido');
+    Verificar(Reader.Count > 0, Nome + ': nenhuma movimentação importada');
+  finally
+    Reader.Free;
+  end;
+end;
+
+procedure ValidarAmostra(const Arquivo: string);
+var
+  Reader: TOFXReader;
+  Cronometro: TStopwatch;
+  DataInicial, DataFinal: TDateTime;
+begin
+  Reader := TOFXReader.Create(nil);
+  try
+    Cronometro := TStopwatch.StartNew;
+    Importar(Reader, Arquivo);
+    Cronometro.Stop;
+    ObterPeriodo(Reader, DataInicial, DataFinal);
+    Writeln(Format('AMOSTRA|%s|%d|%s|%s|%.2f|%.3fms', [
+      ExtractFileName(Arquivo), Reader.Count,
+      FormatDateTime('yyyy-mm-dd', DataInicial),
+      FormatDateTime('yyyy-mm-dd', DataFinal), Somar(Reader),
+      Cronometro.Elapsed.TotalMilliseconds]));
+  finally
+    Reader.Free;
+  end;
+end;
+
+var
+  I: Integer;
+begin
+  try
+    TestarModeloBancoBrasil;
+    TestarUtf8PontoVirgula;
+    TestarCabecalhoInvalido;
+    TestarFormatoLegado('regressao.ofx');
+    TestarFormatoLegado('regressao.ofc');
+    Writeln('OK - TOFXReader importou OFX/OFC/CSV, ignorou saldos e normalizou sinais, codificação e separadores.');
+    for I := 1 to ParamCount do
+      ValidarAmostra(ParamStr(I));
+    ExitCode := 0;
+  except
+    on E: Exception do
+    begin
+      Writeln('FALHA - ' + E.Message);
+      ExitCode := 1;
+    end;
+  end;
+end.

--- a/tests/CSV/fixtures/banco-brasil.csv
+++ b/tests/CSV/fixtures/banco-brasil.csv
@@ -1,0 +1,7 @@
+"Data","Lançamento","Detalhes","N° documento","Valor","Tipo Lançamento"
+"30/06/2026","Saldo Anterior","","","1.000,00",""
+"01/07/2026","Pix - Recebido","CLIENTE, TESTE","11111111111111","240,00","Entrada"
+"00/00/0000","Saldo do dia","","","1.240,00",""
+"02/07/2026","Pagamento de Boleto","FORNECEDOR TESTE","22222222222222","100,50","Saída"
+"03/07/2026","Tarifa","MANUTENÇÃO DE CONTA","33333333333333","-9,95","Saída"
+"31/07/2026","S A L D O","","","1.129,55",""

--- a/tests/CSV/fixtures/cabecalho-invalido.csv
+++ b/tests/CSV/fixtures/cabecalho-invalido.csv
@@ -1,0 +1,2 @@
+Quando;O que;Quanto
+01/07/2026;Teste;10,00

--- a/tests/CSV/fixtures/utf8-ponto-virgula.csv
+++ b/tests/CSV/fixtures/utf8-ponto-virgula.csv
@@ -1,0 +1,5 @@
+Data Movimento;Descrição;Documento;Valor;Natureza
+2026-08-01;Recebimento;A1;10.25;Credit
+2026-08-02;"Compra; material";A2;5,25;Debit
+2026-08-03;Ajuste;;R$ 2,0;Entrada
+2026-08-03;Ajuste;;R$ 2,0;Entrada

--- a/tests/CSV/run-tests.ps1
+++ b/tests/CSV/run-tests.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$OutputRoot = 'G:\Desenvolvimento\OFX-Reader_csv_20260910\regressao',
+    [string[]]$SampleFiles = @()
+)
+
+$ErrorActionPreference = 'Stop'
+$testRoot = $PSScriptRoot
+$resolvedOutput = [IO.Path]::GetFullPath($OutputRoot)
+if (-not $resolvedOutput.StartsWith('G:\Desenvolvimento\', [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'A saída dos testes deve ficar em G:\Desenvolvimento.'
+}
+
+New-Item -ItemType Directory -Path $resolvedOutput -Force | Out-Null
+$fixtureOutput = Join-Path $resolvedOutput 'fixtures'
+New-Item -ItemType Directory -Path $fixtureOutput -Force | Out-Null
+Copy-Item (Join-Path $testRoot 'fixtures\*') $fixtureOutput -Force
+Copy-Item (Join-Path $testRoot '..\..\ofx-files\BancodoBrasil.ofx') (Join-Path $fixtureOutput 'regressao.ofx') -Force
+Copy-Item (Join-Path $testRoot '..\..\ofx-files\extrato.ofc') (Join-Path $fixtureOutput 'regressao.ofc') -Force
+
+$namespaces = 'Vcl;Vcl.Imaging;System;System.Win;Xml;Xml.Win;Data;Data.Win;Datasnap;Datasnap.Win;Web;Web.Win;Soap;Soap.Win;Winapi'
+$command = 'call "C:\Program Files (x86)\Embarcadero\Studio\23.0\bin\rsvars.bat" && ' +
+    'cd /d "' + $testRoot + '" && ' +
+    '"C:\Program Files (x86)\Embarcadero\Studio\23.0\bin\dcc32.exe" -B -Q ' +
+    '-E"' + $resolvedOutput + '" -N0"' + $resolvedOutput + '" -NS"' + $namespaces +
+    '" "CsvReaderTests.dpr"'
+& cmd.exe /c $command
+if ($LASTEXITCODE -ne 0) { throw "Falha na compilação: $LASTEXITCODE" }
+
+& (Join-Path $resolvedOutput 'CsvReaderTests.exe') @SampleFiles
+if ($LASTEXITCODE -ne 0) { throw "Falha nos testes: $LASTEXITCODE" }


### PR DESCRIPTION
## Summary
- add CSV bank statement support through the existing `TOFXReader.Import` API
- keep CSV parsing isolated in `src/uExtratoCsvReader.pas`
- support quoted fields, comma/semicolon/tab delimiters, UTF-8/UTF-16/Windows-1252, common statement headers, and Brazilian/international amounts
- ignore balance rows and expose a stable `SourceKey` for duplicate transaction handling
- preserve OFX/OFC behavior and Lazarus/FPC compilation; CSV support is enabled for Delphi builds

## Tests
- `tests/CSV/run-tests.ps1`
- regression coverage for OFX, OFC, CSV fixtures, invalid headers, duplicate transactions, encodings, delimiters, and signed amounts
- validated with Delphi 12 Win32 against two real bank statement samples (43 and 34 transactions)